### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Form Builder example service
 
 ## Pre-requisites
 
-  [Node](https://nodejs.org)
+  [Docker](https://www.docker.com/products/docker-desktop)
 
 ## Installing
 
@@ -13,7 +13,7 @@ git clone git@github.com:ministryofjustice/fb-example-service.git
 
 git clone git@github.com:ministryofjustice/fb-runner-node.git
 cd fb-runner-node
-npm install
+docker build -t fb-runner-node .
 ```
 
 ## Usage
@@ -21,5 +21,5 @@ npm install
 ```
 cd fb-runner-node
 
-SERVICE_PATH=<PATHTO>/fb-example-service npm start
+docker run -it -p <LOCAL_PORT_NUMBER>:3000 --rm -v <PATH_TO>/fb-example-service:/usr/src/fb-service -e SERVICE_PATH="/usr/src/fb-service" fb-runner-node
 ```

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ npm install
 ```
 cd fb-runner-node
 
-SERVICEDATA=<PATHTO>/fb-example-service npm start
+SERVICE_PATH=<PATHTO>/fb-example-service npm start
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fb-example-servie
+# fb-example-service
 
 Form Builder example service
 


### PR DESCRIPTION
Main point of this change was because the README mentioned a `SERVICEDATA` environment variable, which seems to no longer exist.

I'm also suggesting changing the docs to use Docker, as that worked for me. (And I didn't want to spend time trying to figure out why my local Node install was broken!)